### PR TITLE
refactor: Readiness no longer utility class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
     suffixed with the specification version, e.g. `mycrplural.group.example.com-v1.yml`
   - The CRD files are generated in the `target/META-INF/fabric8` directory of your project
 
-_**Note**_: Breaking changes in the API
+#### _**Note**_: Breaking changes in the API
 ##### DSL Changes:
 - `client.settings()` DSL has been removed since PodPreset v1alpha1 API is no longer present in Kubernetes 1.20.x
 - `client.customResourceDefinitions()` has been removed. Use `client.apiextensions().v1beta1().customResourceDefinitions()` instead

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -254,7 +254,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     throw new KubernetesClientException("Cannot edit read-only resources");
   }
 
-  @Override 
+  @Override
   public <V> T edit(final Class<V> visitorType, final Visitor<V> visitor) {
     return edit(new TypedVisitor<V>() {
         @Override
@@ -1085,14 +1085,18 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     return apiVersion != null && apiVersion.indexOf('/') > 0;
   }
 
+  public Readiness getReadiness() {
+    return Readiness.getInstance();
+  }
+
   @Override
-  public Boolean isReady() {
-    return Readiness.isReady(get());
+  public final Boolean isReady() {
+    return getReadiness().isReady(get());
   }
 
   @Override
   public T waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
-    return waitUntilCondition(resource -> Objects.nonNull(resource) && Readiness.isReady(resource), amount, timeUnit);
+    return waitUntilCondition(resource -> Objects.nonNull(resource) && getReadiness().isReady(resource), amount, timeUnit);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -242,9 +242,13 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl ex
     return h.watch(client, config, meta.getMetadata().getNamespace(), meta, options, watcher);
   }
 
+  protected Readiness getReadiness() {
+    return Readiness.getInstance();
+  }
+
   @Override
-  public Boolean isReady() {
-    return Readiness.isReady(get());
+  public final Boolean isReady() {
+    return getReadiness().isReady(get());
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -206,7 +206,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
   @Override
   public Boolean isReady() {
     for (final HasMetadata meta : acceptVisitors(get(), visitors)) {
-      if (!isResourceReady(meta)) {
+      if (!getReadiness().isReady(meta)) {
         return false;
       }
     }
@@ -403,11 +403,11 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
     return new NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl(client, config, fallbackNamespace, explicitNamespace, fromServer, true, visitors, item, null, null, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
   }
 
-  protected boolean isResourceReady(HasMetadata meta) {
-    return Readiness.isReady(meta);
+  protected Readiness getReadiness() {
+    return Readiness.getInstance();
   }
 
-  protected <T> List<HasMetadata> asHasMetadata(T item, Boolean enableProccessing) {
+  protected <T> List<HasMetadata> asHasMetadata(T item, Boolean enableProcessing) {
     List<HasMetadata> result = new ArrayList<>();
     if (item instanceof KubernetesList) {
       result.addAll(((KubernetesList) item).getItems());
@@ -417,7 +417,7 @@ Waitable<List<HasMetadata>, HasMetadata>, Readiable {
       result.add((HasMetadata) item);
     }  else if (item instanceof String) {
       try (InputStream is = new ByteArrayInputStream(((String)item).getBytes(StandardCharsets.UTF_8))) {
-        return asHasMetadata(unmarshal(is), enableProccessing);
+        return asHasMetadata(unmarshal(is), enableProcessing);
       } catch (IOException e) {
         throw KubernetesClientException.launderThrowable(e);
       }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessWatcher.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessWatcher.java
@@ -38,7 +38,7 @@ public class ReadinessWatcher<T extends HasMetadata> implements Watcher<T> {
   public void eventReceived(Action action, T resource) {
     switch (action) {
       case MODIFIED:
-        if (Readiness.isReady(resource)) {
+        if (Readiness.getInstance().isReady(resource)) {
           reference.set(resource);
           latch.countDown();
         }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/KubernetesResourceUtil.java
@@ -356,7 +356,7 @@ public class KubernetesResourceUtil {
    * @return boolean value indicating it's status
    */
   public static boolean isResourceReady(HasMetadata item) {
-    return Readiness.isReady(item);
+    return Readiness.getInstance().isReady(item);
   }
 
   /**

--- a/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessTest.java
+++ b/kubernetes-client/src/test/java/io/fabric8/kubernetes/client/internal/readiness/ReadinessTest.java
@@ -15,56 +15,63 @@
  */
 package io.fabric8.kubernetes.client.internal.readiness;
 
-import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ReadinessTest {
+class ReadinessTest {
+
+  private Readiness readiness;
+
+  @BeforeEach
+  void setUp() {
+    readiness = Readiness.getInstance();
+  }
 
   @Test
-  public void testStatefulSetReadinessNoSpecNoStatus() {
+  void testStatefulSetReadinessNoSpecNoStatus() {
     StatefulSet statefulSet = new StatefulSet();
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
   }
 
   @Test
-  public void testStatefulSetReadinessNoSpec() {
+  void testStatefulSetReadinessNoSpec() {
     StatefulSetStatus status = new StatefulSetStatus();
 
     StatefulSet statefulSet = new StatefulSet();
     statefulSet.setStatus(status);
 
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
 
     status.setReadyReplicas(1);
 
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
   }
 
   @Test
-  public void testStatefulSetReadinessNoStatus() {
+  void testStatefulSetReadinessNoStatus() {
     StatefulSetSpec spec = new StatefulSetSpec();
     spec.setReplicas(1);
 
     StatefulSet statefulSet = new StatefulSet();
     statefulSet.setSpec(spec);
 
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
 
   }
 
   @Test
-  public void testStatefulSetReadinessNotEnoughReadyReplicas() {
+  void testStatefulSetReadinessNotEnoughReadyReplicas() {
     StatefulSetStatus status = new StatefulSetStatus();
     status.setReadyReplicas(1);
     status.setReplicas(2);
@@ -76,12 +83,12 @@ public class ReadinessTest {
     statefulSet.setStatus(status);
     statefulSet.setSpec(spec);
 
-    assertFalse(Readiness.isReady(statefulSet));
+    assertFalse(readiness.isReady(statefulSet));
     assertFalse(Readiness.isStatefulSetReady(statefulSet));
   }
 
   @Test
-  public void testStatefulSetReadiness() {
+  void testStatefulSetReadiness() {
     StatefulSetStatus status = new StatefulSetStatus();
     status.setReadyReplicas(2);
     status.setReplicas(2);
@@ -93,17 +100,17 @@ public class ReadinessTest {
     statefulSet.setStatus(status);
     statefulSet.setSpec(spec);
 
-    assertTrue(Readiness.isReady(statefulSet));
+    assertTrue(readiness.isReady(statefulSet));
     assertTrue(Readiness.isStatefulSetReady(statefulSet));
   }
 
   @Test
   void testReadinessWithNonNullResource() {
-    assertTrue(Readiness.isReady(new ServiceBuilder().withNewMetadata().withName("svc1").endMetadata().build()));
+    assertTrue(readiness.isReady(new ServiceBuilder().withNewMetadata().withName("svc1").endMetadata().build()));
   }
 
   @Test
   void testReadinessNullResource() {
-    assertFalse(Readiness.isReady(null));
+    assertFalse(readiness.isReady(null));
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/dsl/internal/OpenShiftOperation.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.client.OpenShiftConfig;
@@ -30,8 +31,6 @@ import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResourceList<T>, R extends Resource<T>>
   extends HasMetadataOperation<T, L, R> {
@@ -102,13 +101,8 @@ public class OpenShiftOperation<T extends HasMetadata, L extends KubernetesResou
   }
 
   @Override
-  public Boolean isReady() {
-    return OpenShiftReadiness.isReady(get());
-  }
-
-  @Override
-  public T waitUntilReady(long amount, TimeUnit timeUnit) throws InterruptedException {
-    return waitUntilCondition(resource -> Objects.nonNull(resource) && OpenShiftReadiness.isReady(resource), amount, timeUnit);
+  public Readiness getReadiness() {
+    return OpenShiftReadiness.getInstance();
   }
 
   private void updateApiVersion() {

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableImpl;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.openshift.client.internal.readiness.OpenShiftReadiness;
 import okhttp3.OkHttpClient;
 
@@ -35,7 +36,7 @@ public class OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicab
   }
 
   @Override
-  public Boolean isReady() {
-    return OpenShiftReadiness.isReady(get());
+  protected Readiness getReadiness() {
+    return OpenShiftReadiness.getInstance();
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/internal/OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -54,8 +54,9 @@ public class OpenShiftNamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicab
     super(client, config, namespace, explicitNamespace, fromServer, deletingExisting, visitors, item, inputStream, parameters, gracePeriodSeconds, propagationPolicy, cascading, watchRetryInitialBackoffMillis, watchRetryBackoffMultiplier);
   }
 
-  protected boolean isResourceReady(HasMetadata meta) {
-    return OpenShiftReadiness.isReady(meta);
+  @Override
+  protected OpenShiftReadiness getReadiness() {
+    return OpenShiftReadiness.getInstance();
   }
 
   @Override

--- a/openshift-client/src/test/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadinessTest.java
+++ b/openshift-client/src/test/java/io/fabric8/openshift/client/internal/readiness/OpenShiftReadinessTest.java
@@ -15,15 +15,25 @@
  */
 package io.fabric8.openshift.client.internal.readiness;
 
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OpenShiftReadinessTest {
+
+  private Readiness readiness;
+
+  @BeforeEach
+  void setUp() {
+    readiness = OpenShiftReadiness.getInstance();
+  }
+
   @Test
   void testOpenShiftReadinessWithDeploymentConfig() {
     DeploymentConfig dc = new DeploymentConfigBuilder()
@@ -31,16 +41,16 @@ class OpenShiftReadinessTest {
       .withNewStatus().withAvailableReplicas(2).withReplicas(2).endStatus()
       .build();
 
-    assertTrue(OpenShiftReadiness.isReady(dc));
+    assertTrue(readiness.isReady(dc));
   }
 
   @Test
   void testOpenShiftReadinessWithNonReadinessApplicableResource() {
-    assertTrue(OpenShiftReadiness.isReady(new ImageStreamBuilder().withNewMetadata().withName("is1").endMetadata().build()));
+    assertTrue(readiness.isReady(new ImageStreamBuilder().withNewMetadata().withName("is1").endMetadata().build()));
   }
 
   @Test
   void testOpenShiftReadinessWithNullResource() {
-    assertFalse(OpenShiftReadiness.isReady(null));
+    assertFalse(readiness.isReady(null));
   }
 }


### PR DESCRIPTION
## Description
refactor: Readiness no longer utility class
 - Allow extensibility to the Readiness class by making it
   instantiatable and removing the utility methods.
 - OpenShiftReadiness extends Readiness base class and overrides
   extensible methods to make the isReady base method OpenShift friendly.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry regarding this change
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have added/updated the [javadocs](https://www.javadoc.io/doc/io.fabric8/kubernetes-client/latest/index.html) and other [documentation](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CHEATSHEET.md) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=fabric8io_kubernetes-client) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/fabric8io/kubernetes-client/tree/master/kubernetes-itests)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your pull request as ready for review
-->
